### PR TITLE
Change Orientation attribute name to vpi_Orientation

### DIFF
--- a/ViewPagerIndicator/ViewPagerIndicator/CirclePageIndicator.cs
+++ b/ViewPagerIndicator/ViewPagerIndicator/CirclePageIndicator.cs
@@ -66,7 +66,7 @@ namespace ViewPagerIndicator
 			var a = context.ObtainStyledAttributes (attrs, Resource.Styleable.CirclePageIndicator, defStyle, Resource.Style.Widget_CirclePageIndicator);
 		
 			mCentered = a.GetBoolean (Resource.Styleable.CirclePageIndicator_centered, defaultCentered);
-			mOrientation = a.GetInt (Resource.Styleable.CirclePageIndicator_orientation, defaultOrientation);
+			mOrientation = a.GetInt (Resource.Styleable.CirclePageIndicator_vpi_orientation, defaultOrientation);
 			mPaintPageFill = new Paint (PaintFlags.AntiAlias);
 			mPaintPageFill.SetStyle (Paint.Style.Fill);
 			mPaintPageFill.Color = a.GetColor (Resource.Styleable.CirclePageIndicator_pageColor, defaultPageColor);

--- a/ViewPagerIndicator/ViewPagerIndicator/Resources/Values/vpi__attrs.xml
+++ b/ViewPagerIndicator/ViewPagerIndicator/Resources/Values/vpi__attrs.xml
@@ -37,7 +37,7 @@
         <!-- Color of the filled circles that represents pages. -->
         <attr name="pageColor" format="color" />
         <!-- Orientation of the indicator. -->
-        <attr name="orientation">
+        <attr name="vpi_orientation">
             <enum name="horizontal" value="0" />
             <enum name="vertical" value="1" />
         </attr>

--- a/ViewPagerIndicator/ViewPagerIndicator/Resources/Values/vpi__styles.xml
+++ b/ViewPagerIndicator/ViewPagerIndicator/Resources/Values/vpi__styles.xml
@@ -28,7 +28,7 @@
         <item name="centered">@bool/default_circle_indicator_centered</item>
         <item name="fillColor">@color/default_circle_indicator_fill_color</item>
         <item name="pageColor">@color/default_circle_indicator_page_color</item>
-        <item name="orientation">@integer/default_circle_indicator_orientation</item>
+        <item name="vpi_orientation">@integer/default_circle_indicator_orientation</item>
         <item name="radius">@dimen/default_circle_indicator_radius</item>
         <item name="snap">@bool/default_circle_indicator_snap</item>
         <item name="strokeColor">@color/default_circle_indicator_stroke_color</item>


### PR DESCRIPTION
Change Orientation attribute name to vpi_Orientation in order to use Android.Support.V7.GridLayout package with ViewPagerIndicator package.

Both are declaring an Orientation attribute.
