### PR TITLE
fix MethodAccessException in SavedState:InitializeCreator

### DIFF
--- a/ViewPagerIndicator/ViewPagerIndicator/CirclePageIndicator.cs
+++ b/ViewPagerIndicator/ViewPagerIndicator/CirclePageIndicator.cs
@@ -2,6 +2,7 @@ using Android.Content;
 using Android.OS;
 using Android.Views;
 using Android.Graphics;
+using Android.Runtime;
 using Android.Support.V4.View;
 using Android.Util;
 using Java.Lang;
@@ -532,12 +533,12 @@ namespace ViewPagerIndicator
 				dest.WriteInt (CurrentPage);
 			}
 			
-			[ExportField ("CREATOR")]
-			static SavedStateCreator InitializeCreator ()
+			[Preserve]
+			public new static IParcelableCreator Creator
 			{
-				return new SavedStateCreator ();
+				get { return new SavedStateCreator(); }
 			}
-			
+
 			class SavedStateCreator : Java.Lang.Object, IParcelableCreator
 			{
 				public Java.Lang.Object CreateFromParcel (Parcel source)


### PR DESCRIPTION
try fix this exception
```
Xamarin caused by: android.runtime.JavaProxyThrowable: System.MethodAccessException: Method `(wrapper dynamic-method) object:dynamic_callback_0 (intptr,intptr)' is inaccessible from method `ViewPagerIndicator.CirclePageIndicator/SavedState:InitializeCreator ()'
Java.Interop.NativeMethods.java_interop_jnienv_alloc_object(intptr, ref intptr, intptr)(wrapper managed-to-native)
Java.Interop.JniEnvironment.object.AllocObject(JniObjectReference type)<a043032cf94a485190047a14918b9f60>:0
Java.Interop.JniType.AllocObject()<a043032cf94a485190047a14918b9f60>:0
Java.Interop.JniPeerMembers.JniInstanceMethods.StartCreateInstance(string constructorSignature, Type declaringType, JniArgumentValue* parameters)<a043032cf94a485190047a14918b9f60>:0
Android.Views.View.BaseSavedState.View(IParcelable superState)<9eb16c47cc8f4aa6b6ac4abed5ff79de>:0
ViewPagerIndicator.CirclePageIndicator.SavedState.CirclePageIndicator(IParcelable superState)<9e187c06bb8c4c57a0c4108bed24a3d9>:0
ViewPagerIndicator.CirclePageIndicator.OnSaveInstanceState()<9e187c06bb8c4c57a0c4108bed24a3d9>:0
Android.Views.View.n_OnSaveInstanceState(IntPtr jnienv, IntPtr native__this)<9eb16c47cc8f4aa6b6ac4abed5ff79de>:0
at (wrapper dynamic-method) System.Object:358ccf2b-bf0e-409f-a5cb-0e0071f6a78b (intptr,intptr)
md51feb2c637a327bf04857a09994ad2806.CirclePageIndicator_SavedState.n_InitializeCreator(Native Method)
md51feb2c637a327bf04857a09994ad2806.CirclePageIndicator_SavedState.InitializeCreator()CirclePageIndicator_SavedState.java:56
md51feb2c637a327bf04857a09994ad2806.CirclePageIndicator_SavedState.<clinit>()CirclePageIndicator_SavedState.java:44
md51feb2c637a327bf04857a09994ad2806.CirclePageIndicator.n_onSaveInstanceState(Native Method)
md51feb2c637a327bf04857a09994ad2806.CirclePageIndicator.onSaveInstanceState()CirclePageIndicator.java:93
android.view.View.dispatchSaveInstanceState()View.java:11939
android.view.ViewGroup.dispatchSaveInstanceState()ViewGroup.java:2573
android.view.View.saveHierarchyState()View.java:11922
com.android.internal.policy.impl.PhoneWindow.saveHierarchyState()PhoneWindow.java:1648
android.app.Activity.onSaveInstanceState()Activity.java:1221
android.support.v4.app.FragmentActivity.onSaveInstanceState()FragmentActivity.java:564
android.support.v7.app.AppCompatActivity.onSaveInstanceState()AppCompatActivity.java:502
android.app.Activity.performSaveInstanceState()Activity.java:1170
android.app.Instrumentation.callActivityOnSaveInstanceState()Instrumentation.java:1317
android.app.ActivityThread.performStopActivityInner()ActivityThread.java:3471
android.app.ActivityThread.handleStopActivity()ActivityThread.java:3530
android.app.ActivityThread.access$900()ActivityThread.java:151
android.app.ActivityThread$H.handleMessage()ActivityThread.java:1357
android.os.Handler.dispatchMessage()Handler.java:99
android.os.Looper.loop()Looper.java:155
android.app.ActivityThread.main()ActivityThread.java:5520
java.lang.reflect.Method.invokeNative(Native Method)
java.lang.reflect.Method.invoke()Method.java:511
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run()ZygoteInit.java:1029
com.android.internal.os.ZygoteInit.main()ZygoteInit.java:796
dalvik.system.NativeStart.main(Native Method)
```